### PR TITLE
fix: Only log errors when running checkov

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,7 @@ RUN useradd -u 2004 -U docker && \
     mkdir /home/docker && \
     chown -R docker:docker /docs /home/docker
 ENV BC_API_URL http://127.0.0.1/
+ENV LOG_LEVEL ERROR
 USER docker
 ENTRYPOINT [ "python" ]
 CMD [ "codacy_checkov.py" ]


### PR DESCRIPTION
Checkov send warnings to the stdout, making the tool
not return a valid json when there are warnings