### PR TITLE
feature: Update fake value for BC_API_URL

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ COPY docs /docs
 RUN useradd -u 2004 -U docker && \
     mkdir /home/docker && \
     chown -R docker:docker /docs /home/docker
-ENV BC_API_URL http://127.0.0.1/
+ENV BC_API_URL foo
 ENV LOG_LEVEL ERROR
 USER docker
 ENTRYPOINT [ "python" ]


### PR DESCRIPTION
Changes the BC_API_URL to foo, to match what checkv itself uses on their tests:

<https://github.com/bridgecrewio/checkov/blob/2921a8ba2c7c467b87bf12c2be530174f85c612c/tests/common/test_platform_integration.py>