### PR TITLE
fix: Fix some files having wrong relative path CY-4744

### DIFF
--- a/docs/multiple-tests/relative-path-single-file/patterns.xml
+++ b/docs/multiple-tests/relative-path-single-file/patterns.xml
@@ -1,0 +1,6 @@
+<module name="root">
+    <module name="CKV_AWS_1" />
+    <module name="CKV_AWS_49" />
+    <module name="CKV_K8S_21" />
+    <module name="CKV_K8S_38" />
+</module>

--- a/docs/multiple-tests/relative-path-single-file/results.xml
+++ b/docs/multiple-tests/relative-path-single-file/results.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<checkstyle version="4.3">
+    <file name="a-folder/terraform.tf">
+        <error source="CKV_AWS_1" line="1" message="Ensure IAM policies that allow full &quot;*-*&quot; administrative privileges are not created" severity="warning" />
+        <error source="CKV_AWS_49" line="1" message="Ensure no IAM policies documents allow &quot;*&quot; as a statement's actions" severity="warning" />
+    </file>
+</checkstyle>

--- a/docs/multiple-tests/relative-path-single-file/src/a-folder/terraform.tf
+++ b/docs/multiple-tests/relative-path-single-file/src/a-folder/terraform.tf
@@ -1,0 +1,10 @@
+data "aws_iam_policy_document" "allow_all" {
+  statement {
+    actions = ["*"]
+    principals {
+      identifiers = ["*"]
+      type        = "AWS"
+    }
+    resources = ["*"]
+  }
+}

--- a/src/codacy_checkov.py
+++ b/src/codacy_checkov.py
@@ -96,7 +96,7 @@ def runTool():
     for report in reports:
         failed_checks = report['results']['failed_checks']
         for failed_check in failed_checks:
-            filename = failed_check['file_path'].lstrip('/')
+            filename = failed_check['repo_file_path'].lstrip('/')
             res.append(Result(
                 filename, failed_check['check_name'], failed_check['check_id'], failed_check['file_line_range'][0]))
     return res


### PR DESCRIPTION
In some corner cases,`file_path` doesn't point to the correct relative path but has the file name only.
This changes the tool to use `repo_file_path` instead which always contains the correct path.