### PR TITLE
fix: Use fake proxy to skip network requests

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,8 +7,6 @@ COPY docs /docs
 RUN useradd -u 2004 -U docker && \
     mkdir /home/docker && \
     chown -R docker:docker /docs /home/docker
-ENV BC_API_URL foo
-ENV LOG_LEVEL ERROR
 USER docker
 ENTRYPOINT [ "python" ]
 CMD [ "codacy_checkov.py" ]

--- a/src/codacy_checkov.py
+++ b/src/codacy_checkov.py
@@ -53,11 +53,16 @@ def runCheckov(config):
     file_opts = ([opt for f in config.files for opt in ['-f', f]]
                  if config.files
                  else ['-d', '.'])
+    processEnv = os.environ.copy()
+    processEnv["http_proxy"] = "http://foo"
+    processEnv["https_proxy"] = "https://foo"
+
     process = Popen(
         ['checkov', '-o', 'json', '--quiet', '--no-guide',
          '--skip-fixes', '--skip-suppressions'] + file_opts + config.rules,
         stdout=PIPE,
-        cwd='/src'
+        cwd='/src',
+        env=processEnv
     )
     stdout = process.communicate()[0]
     return json.loads(stdout.decode('utf-8'))

--- a/src/codacy_checkov.py
+++ b/src/codacy_checkov.py
@@ -56,6 +56,8 @@ def runCheckov(config):
     processEnv = os.environ.copy()
     processEnv["http_proxy"] = "http://foo"
     processEnv["https_proxy"] = "https://foo"
+    processEnv["BC_API_URL"] = "foo"
+    processEnv["LOG_LEVEL"] = "ERROR"
 
     process = Popen(
         ['checkov', '-o', 'json', '--quiet', '--no-guide',


### PR DESCRIPTION
`http_proxy` and `https_proxy` env variables are read by Python network stack to do HTTP calls.
By setting them to a name that is readily rejected we make Checkov fallback to the behaviour it has when there is no network ( like what happens with `--net=none` on Docker )