### PR TITLE
feature: Update Checkov to 2.0.399

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-checkov==2.0.283
+checkov==2.0.399
 jsonpickle==1.4.1

--- a/src/codacy_checkov.py
+++ b/src/codacy_checkov.py
@@ -54,10 +54,9 @@ def runCheckov(config):
                  if config.files
                  else ['-d', '.'])
     processEnv = os.environ.copy()
-    processEnv["http_proxy"] = "http://foo"
-    processEnv["https_proxy"] = "https://foo"
-    processEnv["BC_API_URL"] = "foo"
-    processEnv["LOG_LEVEL"] = "ERROR"
+    processEnv["http_proxy"] = "http://127.0.0.1"
+    processEnv["https_proxy"] = "https://127.0.0.1"
+    processEnv["BC_API_URL"] = "127.0.0.1"
 
     process = Popen(
         ['checkov', '-o', 'json', '--quiet', '--no-guide',


### PR DESCRIPTION
- Change fake proxies and BC_API_URL to 127.0.0.1 to avoid k8s DNS
- Remove `LOG_LEVEL` workaround since it is not needed after: https://github.com/bridgecrewio/checkov/pull/993
  Because the tool now logs to STDERR making STDOUT parseable.
- When the network is not available, checkov < `2.0.285` is failing
  trying to access a map which is not defined.
  This version fixed the problem.
  https://github.com/bridgecrewio/checkov/pull/1405/files#diff-83a7665ffac295dc2773f5e32e4c73d78da1189fc93f8365b69b61a0a17d6c50L134