### PR TITLE
fix: Python versioning

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,8 +15,8 @@ workflows:
             # Install Ammonite
             sudo sh -c '(echo "#!/usr/bin/env sh" && curl -L https://github.com/lihaoyi/Ammonite/releases/download/2.3.8/2.13-2.3.8) > /usr/local/bin/amm && chmod +x /usr/local/bin/amm'
             # Install Checkov
-            sudo apt-get update
-            sudo apt-get install python3-pip
+            sudo apt-get update # This is failing due to key signature problems
+            python3 -m pip install --upgrade pip
             pip3 install -r requirements.txt
             # Run doc-generator
             amm doc-generator.sc

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 cffi==1.15.1
 checkov==2.1.188
 jsonpickle==2.2.0
+packaging<22.0


### PR DESCRIPTION
Me and @tfrgoncalves were looking into this, and there are more people having trouble with checkov and their python dependencies.

We had to restrict the version of "packaging" to avoid dependency conflicts with checkov, which crashed when being called.

Also, there is a problem with the Ubuntu machine, which prevents the update of the system due to key signature issues (commented in the `.circleci.yml` file.)

This combination of versions was discovered through trial and error and the pip upgrade might break it again in the future, so it is important to keep that in mind.

The "true" fix, might require work on checkov upstream, which is not our responsibility. 