### PR TITLE
fix: build step in circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,18 +8,26 @@ workflows:
   compile_test_deploy:
     jobs:
       - codacy/checkout_and_version
-      - codacy/sbt:
+      - codacy/shell:
           name: build_docker_and_test
           context: CodacyCircleCI
+          persist_to_workspace: true
           cmd: |
             # Install scala-cli
             curl -sSLf https://virtuslab.github.io/scala-cli-packages/scala-setup.sh | sh
             source ~/.profile
             sudo apt-get update # This is failing due to key signature problems
+
+            # update java
+            sudo apt install openjdk-17-jre
+            sudo update-java-alternatives --auto
+
             python3 -m pip install --upgrade pip
             pip3 install -r requirements.txt
+
             # Run doc-generator
             scala-cli run doc-generator.sc
+
             # Build and same Docker image
             docker build -t $CIRCLE_PROJECT_REPONAME:latest .
             docker save --output docker-image.tar $CIRCLE_PROJECT_REPONAME:latest

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,5 @@ cffi==1.15.1
 checkov==3.0.23
 jsonpickle==3.0.2
 packaging<=23.2
+# Required for python 3.12 compatibility. Consider removing in future releases
+aiohttp==3.9.0b1


### PR DESCRIPTION
This fixes the build step by using java 17, which is now required by scala-cli, and by using the latest version of aiohttp, which is compatible with python 3.12 (earlier versions will fail building wheel).

Note that the toll itself will fail in tests since you seem to be using some deprecated or non-existing command line options.